### PR TITLE
refactor: add 'inputs.path' and pushd/popd before running commands

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,5 +1,10 @@
 name: Build .NET
 inputs:
+  path:
+    description: path from where to run the actions
+    type: string
+    required: false
+    default: ${{ github.workspace }}
   configuration:
     required: false
     default: Debug
@@ -11,6 +16,7 @@ runs:
   - name: Build (${{ inputs.configuration }}) ${{ inputs.framework }}
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       configuration=${{ inputs.configuration }}
       framework=${{ inputs.framework }}
       for a in $(rg --files-with-matches  --type-add "csp:*.csproj" -tcsp "${framework}"); do
@@ -18,3 +24,4 @@ runs:
         echo dotnet build -f ${framework} -c ${configuration} $a
         dotnet build -f ${framework} -c ${configuration} $a
       done
+      popd

--- a/.github/actions/csharpier-check/action.yml
+++ b/.github/actions/csharpier-check/action.yml
@@ -1,8 +1,16 @@
 name: Check for correct formatting using CSharpier
+inputs:
+  path:
+    description: path from where to run the actions
+    type: string
+    required: false
+    default: ${{ github.workspace }}
 runs:
   using: composite
   steps:
   - name: Run CSharpier check
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       dotnet csharpier --check `fdfind cs$`
+      popd

--- a/.github/actions/csharpier-format/action.yml
+++ b/.github/actions/csharpier-format/action.yml
@@ -1,16 +1,28 @@
 name: Format source using CSharpier
+inputs:
+  path:
+    description: path from where to run the actions
+    type: string
+    required: false
+    default: ${{ github.workspace }}
 runs:
   using: composite
   steps:
   - name: Run CSharpier
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       dotnet csharpier `fdfind cs$`
+      popd
   - name: Fix line endings
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       dos2unix `fdfind cs$`
+      popd
   - name: Remove byte order mark (BOM)
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       LANG=C LC_ALL=C sed -i '1s/^\xEF\xBB\xBF//' `fdfind cs$`
+      popd

--- a/.github/actions/nuget-fetch/action.yml
+++ b/.github/actions/nuget-fetch/action.yml
@@ -1,5 +1,10 @@
 name: Fetch NuGet package from registry
 inputs:
+  path:
+    description: path from where to run the actions
+    type: string
+    required: false
+    default: ${{ github.workspace }}
   package:
     required: true
   registry:
@@ -23,6 +28,8 @@ runs:
   - name: Fetch package ${{ inputs.package }}
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
+
       source=${{ inputs.registry }}
       [[ ! -z ${source} ]] && source="-Source ${source}"
 
@@ -39,3 +46,4 @@ runs:
 
       echo "nuget install ${{ inputs.package }} ${version} ${prerelease} -DirectDownload -NonInteractive  ${outdir} ${framework} ${source}"
       nuget install ${{ inputs.package }} ${version} ${prerelease} -DirectDownload -NonInteractive  ${outdir} ${framework} ${source}
+      popd

--- a/.github/actions/nuget-pack/action.yml
+++ b/.github/actions/nuget-pack/action.yml
@@ -1,5 +1,10 @@
 name: nuget pack
 inputs:
+  path:
+    description: path from where to run the actions
+    type: string
+    required: false
+    default: ${{ github.workspace }}
   configuration:
     required: false
     default: Release
@@ -15,8 +20,10 @@ runs:
   - name: Run nuget pack with ${{ inputs.framework }}
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       framework=${{ inputs.framework }}
       for a in $(rg --files-with-matches  --type-add "csp:*.csproj" -tcsp "${framework}"); do
         dotnet pack -c ${{ inputs.configuration }} -p:TargetFramework=${framework} $a || echo "Error"
       done
       fdfind --no-ignore nupkg$
+      popd

--- a/.github/actions/nuget-publish/action.yml
+++ b/.github/actions/nuget-publish/action.yml
@@ -1,5 +1,10 @@
 name: nuget publish
 inputs:
+  path:
+    description: path from where to run the actions
+    type: string
+    required: false
+    default: ${{ github.workspace }}
   registry:
     required: false
     default: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
@@ -11,5 +16,7 @@ runs:
   - name: nuget push to ${{ inputs.registry }}
     shell: bash
     run: |-
+      pushd ${{ inputs.path }}
       fdfind --no-ignore nupkg$
       fdfind --no-ignore nupkg$ -x dotnet nuget push {} --api-key ${{ inputs.token }}  --source "${{ inputs.registry }}"
+      popd


### PR DESCRIPTION
- refactor ('build' action): add inputs.path and pushd/popd before running commands
- refactor ('csharpier-check' action): add inputs.path and pushd/popd before running commands
- refactor ('csharpier-format' action): add inputs.path and pushd/popd before running commands
- refactor ('nuget-fetch' action): add inputs.path and pushd/popd before running commands
- refactor ('nuget-pack' action): add inputs.path and pushd/popd before running commands
- refactor ('nuget-publish' action): add inputs.path and pushd/popd before running commands
