### PR TITLE
refactor ('dll-get-version' action): use powershell instead of bash calling into powershell

### DIFF
--- a/.github/actions/dll-get-version/action.yml
+++ b/.github/actions/dll-get-version/action.yml
@@ -12,11 +12,11 @@ runs:
   steps:
   - id: get
     name: Get package version from ${{ inputs.file }}
-    shell: bash
+    shell: pwsh
     run: |-
-      version=$(pwsh -Command "(get-item ${{ inputs.file }}).VersionInfo.ProductVersion")
-      echo ${version}
-      echo "version=${version}" >> $GITHUB_OUTPUT
+      $version = $((Get-Item ${{ inputs.file }}).VersionInfo.ProductVersion) -join "`n"
+      Write-Output $version
+      Write-Output $version >> $Env:GITHUB_OUTPUT
   - shell: bash
     run: |-
       echo ${{ steps.get.outputs.version }}


### PR DESCRIPTION
to get outputs from 'Get-Item'
