### PR TITLE
fix ('dll-get-version' action): correct outformat when writing to $GITHUB_OUTPUT

### DIFF
--- a/.github/actions/dll-get-version/action.yml
+++ b/.github/actions/dll-get-version/action.yml
@@ -15,8 +15,8 @@ runs:
     shell: pwsh
     run: |-
       $version = $((Get-Item ${{ inputs.file }}).VersionInfo.ProductVersion) -join "`n"
-      Write-Output $version
-      Write-Output $version >> $Env:GITHUB_OUTPUT
+      echo "version: $version"
+      echo "version=$version" >> $Env:GITHUB_OUTPUT
   - shell: bash
     run: |-
       echo ${{ steps.get.outputs.version }}


### PR DESCRIPTION
detail: was missing variable name 'version='
