### PR TITLE
fix ('nuget-publish' action): avoid pushing symbol nupkg files separately

### DIFF
--- a/.github/actions/nuget-publish/action.yml
+++ b/.github/actions/nuget-publish/action.yml
@@ -17,6 +17,6 @@ runs:
     shell: bash
     run: |-
       pushd ${{ inputs.path }}
-      fdfind -tf --no-ignore nupkg$
-      fdfind -tf --no-ignore nupkg$ -x dotnet nuget push {} --api-key ${{ inputs.token }}  --source "${{ inputs.registry }}"
+      fdfind -tf --no-ignore "\.nupkg$"
+      fdfind -tf --no-ignore "\.nupkg$" -x dotnet nuget push {} --api-key ${{ inputs.token }}  --source "${{ inputs.registry }}"  --skip-duplicate
       popd

--- a/.github/actions/nuget-publish/action.yml
+++ b/.github/actions/nuget-publish/action.yml
@@ -17,6 +17,6 @@ runs:
     shell: bash
     run: |-
       pushd ${{ inputs.path }}
-      fdfind -tf --no-ignore "\.nupkg$"
-      fdfind -tf --no-ignore "\.nupkg$" -x dotnet nuget push {} --api-key ${{ inputs.token }}  --source "${{ inputs.registry }}"  --skip-duplicate
+      fdfind -tf --no-ignore "[^(\.symbols)]\.nupkg$"
+      fdfind -tf --no-ignore "[^(\.symbols)]\.nupkg$" -x dotnet nuget push {} --api-key ${{ inputs.token }}  --source "${{ inputs.registry }}"  --skip-duplicate
       popd


### PR DESCRIPTION
- refactor ('nuget-publish' action): add failsafe for duplicate pushes with '--skip-duplicate'
- refactor ('nuget-publish' action): only push non-symbol .nupkg files
