### PR TITLE
refactor ('nuget-add-registry' action): add support for adding registries that do not require credentials

### DIFF
--- a/.github/actions/nuget-add-registry/action.yml
+++ b/.github/actions/nuget-add-registry/action.yml
@@ -1,14 +1,21 @@
 name: Add NuGet Registry
+description: >
+  GitHub action to add a NuGet registry
+
 inputs:
   name:
+    description: Name/Alias of the NuGet registry to add (must be unique)
     required: true
   registry:
+    description: URL of the NuGet registry to add
     required: false
     default: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
   username:
+    description: A valid username for the given registry
     required: false
     default: ${{ github.repository_owner }}
   token:
+    description: A GitHub token with "packages:read" permissions for the given registry
     required: true
 runs:
   using: composite

--- a/.github/actions/nuget-add-registry/action.yml
+++ b/.github/actions/nuget-add-registry/action.yml
@@ -21,8 +21,13 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Add NuGet source ${{ inputs.registry }}
-    if: inputs.registry != 'https://api.nuget.org/v3/index.json'
+  - name: Add NuGet source ${{ inputs.registry }} with credentials
+    if: ${{ inputs.registry != 'https://api.nuget.org/v3/index.json' }}
+    shell: bash
+    run: |-
+      dotnet nuget add source --username "${{ inputs.username }}" --password "${{ inputs.token }}" --store-password-in-clear-text --name ${{ inputs.name }} "${{ inputs.registry }}"
+  - name: Add NuGet source ${{ inputs.registry }} without credentials
+    if: ${{ inputs.registry != 'https://api.nuget.org/v3/index.json' && (inputs.username == '' || inputs.token == '') }}
     shell: bash
     run: |-
       dotnet nuget add source --username "${{ inputs.username }}" --password "${{ inputs.token }}" --store-password-in-clear-text --name ${{ inputs.name }} "${{ inputs.registry }}"

--- a/.github/actions/nuget-add-registry/action.yml
+++ b/.github/actions/nuget-add-registry/action.yml
@@ -16,7 +16,8 @@ inputs:
     default: ${{ github.repository_owner }}
   token:
     description: A GitHub token with "packages:read" permissions for the given registry
-    required: true
+    required: false
+    default: ${{ github.token }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
- **refactor ('nuget-add-registry' action): add action and inputs descriptions**
- **refactor ('nuget-add-registry' action): make inputs.token optional and default to github.token**
- **refactor ('nuget-add-registry' action): add support for adding registries that do not require credentials**
